### PR TITLE
TotalEat画面のレイアウト作成

### DIFF
--- a/natto/Common/Localize/LocalizeKey.swift
+++ b/natto/Common/Localize/LocalizeKey.swift
@@ -90,4 +90,14 @@ struct LocalizeKeys {
             return rawValue
         }
     }
+    
+    enum TotalEat: String, LocalizeKeyGeneratable {
+        case eatNatto = "TOTALEAT.EATNATTO"
+        case grouth = "TOTALEAT.GROUTH"
+        case grain = "TOTALEAT.GRAIN"
+        
+        var key: String {
+            return rawValue
+        }
+    }
 }

--- a/natto/View/Result/Select/TotalEat/TotalEatViewController.swift
+++ b/natto/View/Result/Select/TotalEat/TotalEatViewController.swift
@@ -20,6 +20,7 @@ class TotalEatViewController: UIViewController {
             totalNattoCountLabel.font = UIFont(name: "Verdana-bold", size: 25)
         }
     }
+    @IBOutlet weak var nextGrouthLabel: UILabel!
     override func viewDidLoad() {
         super.viewDidLoad()
         self.view.backgroundColor = AppColor.background.color

--- a/natto/View/Result/Select/TotalEat/TotalEatViewController.swift
+++ b/natto/View/Result/Select/TotalEat/TotalEatViewController.swift
@@ -13,14 +13,23 @@ class TotalEatViewController: UIViewController {
     @IBOutlet weak var totalNattoDescriptionLabel: UILabel!{
         didSet {
             totalNattoDescriptionLabel.font = UIFont(name: "Verdana-bold", size: 25)
+            totalNattoDescriptionLabel.text = localizeString(key: LocalizeKeys.TotalEat.eatNatto)
         }
     }
     @IBOutlet weak var totalNattoCountLabel: UILabel!{
         didSet {
             totalNattoCountLabel.font = UIFont(name: "Verdana-bold", size: 25)
+            totalNattoCountLabel.text = localizeString(key: LocalizeKeys.TotalEat.grouth)
         }
     }
-    @IBOutlet weak var nextGrouthLabel: UILabel!
+    @IBOutlet weak var nextGrouthLabel: UILabel!{
+        didSet {
+            nextGrouthLabel.font = UIFont(name: "Verdana-bold", size: 25)
+            nextGrouthLabel.text = localizeString(key: LocalizeKeys.TotalEat.grouth, "123456789")
+        }
+    }
+    
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         self.view.backgroundColor = AppColor.background.color

--- a/natto/View/Result/Select/TotalEat/TotalEatViewController.swift
+++ b/natto/View/Result/Select/TotalEat/TotalEatViewController.swift
@@ -10,31 +10,41 @@ import UIKit
 
 class TotalEatViewController: UIViewController {
 
-    @IBOutlet weak var totalNattoDescriptionLabel: UILabel!{
-        didSet {
-            totalNattoDescriptionLabel.font = UIFont(name: "Verdana-bold", size: 25)
-            totalNattoDescriptionLabel.text = localizeString(key: LocalizeKeys.TotalEat.eatNatto)
-        }
-    }
-    @IBOutlet weak var totalNattoCountLabel: UILabel!{
-        didSet {
-            totalNattoCountLabel.font = UIFont(name: "Verdana-bold", size: 25)
-            totalNattoCountLabel.text = localizeString(key: LocalizeKeys.TotalEat.grouth)
-        }
-    }
-    @IBOutlet weak var nextGrouthLabel: UILabel!{
-        didSet {
-            nextGrouthLabel.font = UIFont(name: "Verdana-bold", size: 25)
-            nextGrouthLabel.text = localizeString(key: LocalizeKeys.TotalEat.grouth, "123456789")
-        }
-    }
-    
+    @IBOutlet weak var totalNattoDescriptionLabel: UILabel!
+    @IBOutlet weak var totalNattoCountLabel: UILabel!
+    @IBOutlet weak var nextGrouthLabel: UILabel!
     
     override func viewDidLoad() {
         super.viewDidLoad()
         self.view.backgroundColor = AppColor.background.color
         let totalNattoCount = UserStore.totalNattoCount
-        totalNattoCountLabel.text = totalNattoCount.description + "粒"
+        
+        commonInit(eatNum: totalNattoCount)
+        setNextGrouthGrain(eatNum: totalNattoCount)
+    }
+    
+    private func commonInit(eatNum: Int){
+        totalNattoCountLabel.text = localizeString(key: LocalizeKeys.TotalEat.grain, eatNum)
+        totalNattoCountLabel.font = UIFont(name: "Verdana-bold", size: 25)
+        
+        totalNattoDescriptionLabel.font = UIFont(name: "Verdana-bold", size: 25)
+        totalNattoDescriptionLabel.text = localizeString(key: LocalizeKeys.TotalEat.eatNatto)
+        
+    }
+    
+    private func setNextGrouthGrain(eatNum: Int){
+        nextGrouthLabel.font = UIFont(name: "Verdana-bold", size: 25)
+        
+        //TODO 画像を入れる
+        if eatNum < 1000 {
+            nextGrouthLabel.text = localizeString(key: LocalizeKeys.TotalEat.grouth, 1000 - eatNum)
+        } else if eatNum > 1000 && eatNum < 3000 {
+            nextGrouthLabel.text = localizeString(key: LocalizeKeys.TotalEat.grouth, 3000 - eatNum)
+        } else if eatNum > 3000 && eatNum < 8000 {
+            nextGrouthLabel.text = localizeString(key: LocalizeKeys.TotalEat.grouth, 8000 - eatNum)
+        } else if eatNum > 8000 {
+            nextGrouthLabel.text = ""
+        }
     }
     
     override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {

--- a/natto/View/Result/Select/TotalEat/TotalEatViewController.xib
+++ b/natto/View/Result/Select/TotalEat/TotalEatViewController.xib
@@ -42,19 +42,19 @@
                     </constraints>
                 </view>
                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="tutorialIcon" translatesAutoresizingMaskIntoConstraints="NO" id="I8z-Sy-3QA">
-                    <rect key="frame" x="16" y="257" width="382" height="382"/>
+                    <rect key="frame" x="24" y="245" width="366" height="366"/>
                     <constraints>
                         <constraint firstAttribute="width" secondItem="I8z-Sy-3QA" secondAttribute="height" multiplier="1:1" id="5hX-s0-l7X"/>
                     </constraints>
                 </imageView>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="なっとうのせいちょうまであと100粒" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Yjz-0g-CGa">
-                    <rect key="frame" x="16" y="663" width="382" height="72"/>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="なっとうのせいちょうまであと100粒" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Yjz-0g-CGa">
+                    <rect key="frame" x="16" y="694" width="382" height="72"/>
                     <fontDescription key="fontDescription" type="system" pointSize="30"/>
                     <color key="textColor" name="white"/>
                     <nil key="highlightedColor"/>
                 </label>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="QXk-4P-BYb">
-                    <rect key="frame" x="107" y="790" width="200" height="36"/>
+                    <rect key="frame" x="107" y="802" width="200" height="36"/>
                     <color key="backgroundColor" name="button"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="36" id="4K3-le-aAA"/>
@@ -81,18 +81,19 @@
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="Yjz-0g-CGa" secondAttribute="trailing" constant="16" id="DKe-7z-kSv"/>
                 <constraint firstItem="QXk-4P-BYb" firstAttribute="centerX" secondItem="Yjz-0g-CGa" secondAttribute="centerX" id="Fkt-iV-1G0"/>
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="1a8-pR-KNV" secondAttribute="trailing" constant="16" id="MiN-9C-90p"/>
-                <constraint firstItem="fnl-2z-Ty3" firstAttribute="bottom" secondItem="QXk-4P-BYb" secondAttribute="bottom" constant="36" id="Qt0-i9-duQ"/>
+                <constraint firstItem="fnl-2z-Ty3" firstAttribute="bottom" secondItem="QXk-4P-BYb" secondAttribute="bottom" constant="24" id="Qt0-i9-duQ"/>
                 <constraint firstItem="W1m-Hh-SWC" firstAttribute="leading" secondItem="RBD-Rb-QOS" secondAttribute="leading" id="RVg-c3-5cs"/>
                 <constraint firstItem="Yjz-0g-CGa" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="16" id="RoF-t5-nGC"/>
-                <constraint firstItem="I8z-Sy-3QA" firstAttribute="centerY" secondItem="i5M-Pr-FkT" secondAttribute="centerY" id="eZu-J4-vp1"/>
+                <constraint firstItem="I8z-Sy-3QA" firstAttribute="centerY" secondItem="i5M-Pr-FkT" secondAttribute="centerY" constant="-20" id="eZu-J4-vp1"/>
                 <constraint firstItem="1a8-pR-KNV" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" constant="16" id="epz-qM-iht"/>
                 <constraint firstItem="W1m-Hh-SWC" firstAttribute="top" secondItem="RBD-Rb-QOS" secondAttribute="bottom" id="ez3-Gx-7xa"/>
                 <constraint firstItem="RBD-Rb-QOS" firstAttribute="top" secondItem="1a8-pR-KNV" secondAttribute="bottom" constant="8" id="hU4-V0-JKz"/>
-                <constraint firstItem="I8z-Sy-3QA" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="16" id="kww-sR-pkQ"/>
-                <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="I8z-Sy-3QA" secondAttribute="trailing" constant="16" id="myb-cD-7Vz"/>
                 <constraint firstItem="1a8-pR-KNV" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="16" id="n6l-R9-MEE"/>
+                <constraint firstItem="QXk-4P-BYb" firstAttribute="top" secondItem="Yjz-0g-CGa" secondAttribute="bottom" constant="36" id="qIr-bb-H0z"/>
+                <constraint firstItem="I8z-Sy-3QA" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="24" id="uOP-6h-UQe"/>
                 <constraint firstItem="I8z-Sy-3QA" firstAttribute="centerX" secondItem="i5M-Pr-FkT" secondAttribute="centerX" id="v3n-mP-EDH"/>
-                <constraint firstItem="Yjz-0g-CGa" firstAttribute="top" secondItem="I8z-Sy-3QA" secondAttribute="bottom" constant="24" id="vvm-8G-c5V"/>
+                <constraint firstItem="Yjz-0g-CGa" firstAttribute="top" relation="greaterThanOrEqual" secondItem="I8z-Sy-3QA" secondAttribute="bottom" id="vvm-8G-c5V"/>
+                <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="I8z-Sy-3QA" secondAttribute="trailing" constant="24" id="wXv-Q5-4N0"/>
             </constraints>
             <point key="canvasLocation" x="120" y="95"/>
         </view>

--- a/natto/View/Result/Select/TotalEat/TotalEatViewController.xib
+++ b/natto/View/Result/Select/TotalEat/TotalEatViewController.xib
@@ -6,7 +6,6 @@
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17126"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
-        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -26,13 +25,13 @@
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="今まで食べた納豆の数" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1a8-pR-KNV">
                     <rect key="frame" x="16" y="60" width="382" height="35"/>
                     <fontDescription key="fontDescription" type="system" pointSize="29"/>
-                    <nil key="textColor"/>
+                    <color key="textColor" name="white"/>
                     <nil key="highlightedColor"/>
                 </label>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="999粒" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="RBD-Rb-QOS">
                     <rect key="frame" x="305.5" y="103" width="72.5" height="30"/>
                     <fontDescription key="fontDescription" type="system" pointSize="25"/>
-                    <nil key="textColor"/>
+                    <color key="textColor" name="white"/>
                     <nil key="highlightedColor"/>
                 </label>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="W1m-Hh-SWC">
@@ -43,15 +42,15 @@
                     </constraints>
                 </view>
                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="tutorialIcon" translatesAutoresizingMaskIntoConstraints="NO" id="I8z-Sy-3QA">
-                    <rect key="frame" x="16" y="207" width="382" height="382"/>
+                    <rect key="frame" x="16" y="257" width="382" height="382"/>
                     <constraints>
                         <constraint firstAttribute="width" secondItem="I8z-Sy-3QA" secondAttribute="height" multiplier="1:1" id="5hX-s0-l7X"/>
                     </constraints>
                 </imageView>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="なっとうのせいちょうまであと100粒" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Yjz-0g-CGa">
-                    <rect key="frame" x="16" y="613" width="382" height="72"/>
+                    <rect key="frame" x="16" y="663" width="382" height="72"/>
                     <fontDescription key="fontDescription" type="system" pointSize="30"/>
-                    <nil key="textColor"/>
+                    <color key="textColor" name="white"/>
                     <nil key="highlightedColor"/>
                 </label>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="QXk-4P-BYb">
@@ -73,8 +72,9 @@
                 </button>
             </subviews>
             <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
-            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+            <color key="backgroundColor" name="background"/>
             <constraints>
+                <constraint firstItem="I8z-Sy-3QA" firstAttribute="top" relation="greaterThanOrEqual" secondItem="W1m-Hh-SWC" secondAttribute="bottom" id="1Ks-Wn-spj"/>
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="RBD-Rb-QOS" secondAttribute="trailing" constant="36" id="3rD-xT-mHl"/>
                 <constraint firstItem="W1m-Hh-SWC" firstAttribute="trailing" secondItem="RBD-Rb-QOS" secondAttribute="trailing" id="4Ik-WE-MU3"/>
                 <constraint firstItem="RBD-Rb-QOS" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="16" id="BI6-Eg-UBc"/>
@@ -84,7 +84,7 @@
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="bottom" secondItem="QXk-4P-BYb" secondAttribute="bottom" constant="36" id="Qt0-i9-duQ"/>
                 <constraint firstItem="W1m-Hh-SWC" firstAttribute="leading" secondItem="RBD-Rb-QOS" secondAttribute="leading" id="RVg-c3-5cs"/>
                 <constraint firstItem="Yjz-0g-CGa" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="16" id="RoF-t5-nGC"/>
-                <constraint firstItem="I8z-Sy-3QA" firstAttribute="centerY" secondItem="i5M-Pr-FkT" secondAttribute="centerY" constant="-50" id="eZu-J4-vp1"/>
+                <constraint firstItem="I8z-Sy-3QA" firstAttribute="centerY" secondItem="i5M-Pr-FkT" secondAttribute="centerY" id="eZu-J4-vp1"/>
                 <constraint firstItem="1a8-pR-KNV" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" constant="16" id="epz-qM-iht"/>
                 <constraint firstItem="W1m-Hh-SWC" firstAttribute="top" secondItem="RBD-Rb-QOS" secondAttribute="bottom" id="ez3-Gx-7xa"/>
                 <constraint firstItem="RBD-Rb-QOS" firstAttribute="top" secondItem="1a8-pR-KNV" secondAttribute="bottom" constant="8" id="hU4-V0-JKz"/>
@@ -99,14 +99,14 @@
     </objects>
     <resources>
         <image name="tutorialIcon" width="600" height="600"/>
+        <namedColor name="background">
+            <color red="0.14901960784313725" green="0.14901960784313725" blue="0.14901960784313725" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
         <namedColor name="button">
             <color red="0.98039215686274506" green="0.58431372549019611" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
         <namedColor name="white">
             <color red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
-        <systemColor name="systemBackgroundColor">
-            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-        </systemColor>
     </resources>
 </document>

--- a/natto/View/Result/Select/TotalEat/TotalEatViewController.xib
+++ b/natto/View/Result/Select/TotalEat/TotalEatViewController.xib
@@ -4,6 +4,7 @@
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17126"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -11,6 +12,7 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="TotalEatViewController" customModule="natto" customModuleProvider="target">
             <connections>
+                <outlet property="nextGrouthLabel" destination="Yjz-0g-CGa" id="J49-M9-vLj"/>
                 <outlet property="totalNattoCountLabel" destination="RBD-Rb-QOS" id="Td5-Ym-C6i"/>
                 <outlet property="totalNattoDescriptionLabel" destination="1a8-pR-KNV" id="qMR-8g-PBP"/>
                 <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
@@ -40,6 +42,35 @@
                         <constraint firstAttribute="height" constant="1" id="YGy-ie-FTC"/>
                     </constraints>
                 </view>
+                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="tutorialIcon" translatesAutoresizingMaskIntoConstraints="NO" id="I8z-Sy-3QA">
+                    <rect key="frame" x="16" y="207" width="382" height="382"/>
+                    <constraints>
+                        <constraint firstAttribute="width" secondItem="I8z-Sy-3QA" secondAttribute="height" multiplier="1:1" id="5hX-s0-l7X"/>
+                    </constraints>
+                </imageView>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="なっとうのせいちょうまであと100粒" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Yjz-0g-CGa">
+                    <rect key="frame" x="16" y="613" width="382" height="72"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="30"/>
+                    <nil key="textColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="QXk-4P-BYb">
+                    <rect key="frame" x="107" y="790" width="200" height="36"/>
+                    <color key="backgroundColor" name="button"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="36" id="4K3-le-aAA"/>
+                        <constraint firstAttribute="width" constant="200" id="Lcg-Wd-dqj"/>
+                    </constraints>
+                    <fontDescription key="fontDescription" type="boldSystem" pointSize="20"/>
+                    <state key="normal" title="とじる">
+                        <color key="titleColor" name="white"/>
+                    </state>
+                    <userDefinedRuntimeAttributes>
+                        <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                            <integer key="value" value="4"/>
+                        </userDefinedRuntimeAttribute>
+                    </userDefinedRuntimeAttributes>
+                </button>
             </subviews>
             <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
             <color key="backgroundColor" systemColor="systemBackgroundColor"/>
@@ -47,17 +78,33 @@
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="RBD-Rb-QOS" secondAttribute="trailing" constant="36" id="3rD-xT-mHl"/>
                 <constraint firstItem="W1m-Hh-SWC" firstAttribute="trailing" secondItem="RBD-Rb-QOS" secondAttribute="trailing" id="4Ik-WE-MU3"/>
                 <constraint firstItem="RBD-Rb-QOS" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="16" id="BI6-Eg-UBc"/>
+                <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="Yjz-0g-CGa" secondAttribute="trailing" constant="16" id="DKe-7z-kSv"/>
+                <constraint firstItem="QXk-4P-BYb" firstAttribute="centerX" secondItem="Yjz-0g-CGa" secondAttribute="centerX" id="Fkt-iV-1G0"/>
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="1a8-pR-KNV" secondAttribute="trailing" constant="16" id="MiN-9C-90p"/>
+                <constraint firstItem="fnl-2z-Ty3" firstAttribute="bottom" secondItem="QXk-4P-BYb" secondAttribute="bottom" constant="36" id="Qt0-i9-duQ"/>
                 <constraint firstItem="W1m-Hh-SWC" firstAttribute="leading" secondItem="RBD-Rb-QOS" secondAttribute="leading" id="RVg-c3-5cs"/>
+                <constraint firstItem="Yjz-0g-CGa" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="16" id="RoF-t5-nGC"/>
+                <constraint firstItem="I8z-Sy-3QA" firstAttribute="centerY" secondItem="i5M-Pr-FkT" secondAttribute="centerY" constant="-50" id="eZu-J4-vp1"/>
                 <constraint firstItem="1a8-pR-KNV" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" constant="16" id="epz-qM-iht"/>
                 <constraint firstItem="W1m-Hh-SWC" firstAttribute="top" secondItem="RBD-Rb-QOS" secondAttribute="bottom" id="ez3-Gx-7xa"/>
                 <constraint firstItem="RBD-Rb-QOS" firstAttribute="top" secondItem="1a8-pR-KNV" secondAttribute="bottom" constant="8" id="hU4-V0-JKz"/>
+                <constraint firstItem="I8z-Sy-3QA" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="16" id="kww-sR-pkQ"/>
+                <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="I8z-Sy-3QA" secondAttribute="trailing" constant="16" id="myb-cD-7Vz"/>
                 <constraint firstItem="1a8-pR-KNV" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="16" id="n6l-R9-MEE"/>
+                <constraint firstItem="I8z-Sy-3QA" firstAttribute="centerX" secondItem="i5M-Pr-FkT" secondAttribute="centerX" id="v3n-mP-EDH"/>
+                <constraint firstItem="Yjz-0g-CGa" firstAttribute="top" secondItem="I8z-Sy-3QA" secondAttribute="bottom" constant="24" id="vvm-8G-c5V"/>
             </constraints>
             <point key="canvasLocation" x="120" y="95"/>
         </view>
     </objects>
     <resources>
+        <image name="tutorialIcon" width="600" height="600"/>
+        <namedColor name="button">
+            <color red="0.98039215686274506" green="0.58431372549019611" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <namedColor name="white">
+            <color red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>

--- a/natto/en.lproj/Localizable.strings
+++ b/natto/en.lproj/Localizable.strings
@@ -45,3 +45,8 @@
 "TOPPINGSELECT.RESET" =  "Reset";
 "TOPPINGSELECT.ALERT.ITEMLESS" = "Not enough items";
 "TOPPINGSELECT.ALERT.SELECTOVER" = "You can use up to 3 toppings";
+
+// TotalEat画面
+"TOTALEAT.EATNATTO" = "Number of natto I have ever eaten";
+"TOTALEAT.GROUTH" = "Until the next growth% @ crush";
+"TOTALEAT.GRAIN" = "grain";

--- a/natto/en.lproj/Localizable.strings
+++ b/natto/en.lproj/Localizable.strings
@@ -48,5 +48,5 @@
 
 // TotalEat画面
 "TOTALEAT.EATNATTO" = "Number of natto I have ever eaten";
-"TOTALEAT.GROUTH" = "Until the next growth% @ crush";
-"TOTALEAT.GRAIN" = "grain";
+"TOTALEAT.GROUTH" = "Until the next growth %d crush";
+"TOTALEAT.GRAIN" = "%dgrain";

--- a/natto/ja.lproj/Localizable.strings
+++ b/natto/ja.lproj/Localizable.strings
@@ -44,3 +44,9 @@
 "TOPPINGSELECT.RESET" =  "リセット";
 "TOPPINGSELECT.ALERT.ITEMLESS" = "アイテムが足りません";
 "TOPPINGSELECT.ALERT.SELECTOVER" = "トッピングは3個まで使用することができます";
+
+// TotalEat画面
+"TOTALEAT.EATNATTO" = "今まで食べた納豆の数";
+"TOTALEAT.GROUTH" = "つぎの成長まであと%@つぶ";
+"TOTALEAT.GRAIN" = "粒";
+

--- a/natto/ja.lproj/Localizable.strings
+++ b/natto/ja.lproj/Localizable.strings
@@ -47,6 +47,6 @@
 
 // TotalEat画面
 "TOTALEAT.EATNATTO" = "今まで食べた納豆の数";
-"TOTALEAT.GROUTH" = "つぎの成長まであと%@つぶ";
-"TOTALEAT.GRAIN" = "粒";
+"TOTALEAT.GROUTH" = "つぎの成長まであと%dつぶ";
+"TOTALEAT.GRAIN" = "%d粒";
 


### PR DESCRIPTION
## 概要
* TotalEat画面のレイアウト作成しました
* 画像の切り替えに関しては別途対応
## スクリーンショット
![Simulator Screen Shot - iPod touch (7th generation) - 2020-11-28 at 20 16 39](https://user-images.githubusercontent.com/42649032/100514285-b414c100-31b6-11eb-8e2a-34a64f01cc60.png)
